### PR TITLE
Add filtering to todo_search

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,18 +2,28 @@
 
 import pytest
 from thingsbridge.tools import (
-    todo_create, project_create, todo_search,
-    todo_list_today, todo_list_inbox, todo_complete
+    todo_create,
+    project_create,
+    todo_search,
+    todo_list_today,
+    todo_list_inbox,
+    todo_complete,
 )
+
 
 # Only run these tests if Things 3 is available
 def things3_available():
     """Check if Things 3 is available for testing."""
     try:
         from thingsbridge.things3 import client
-        return client.executor.check_things_running() or client.executor.ensure_things_running().success
+
+        return (
+            client.executor.check_things_running()
+            or client.executor.ensure_things_running().success
+        )
     except:
         return False
+
 
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_create_todo_basic():
@@ -23,6 +33,7 @@ def test_create_todo_basic():
     assert "Test Todo from MCP" in result
     assert "ID:" in result
 
+
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_create_todo_with_scheduling():
     """Test todo creation with scheduling."""
@@ -30,12 +41,14 @@ def test_create_todo_with_scheduling():
     assert "✅ Created todo" in result
     assert "Scheduled Todo" in result
 
+
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_create_todo_with_tags():
     """Test todo creation with tags."""
     result = todo_create("Tagged Todo", "Has tags", tags=["test", "mcp"])
     assert "✅ Created todo" in result
     assert "Tagged Todo" in result
+
 
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_create_project():
@@ -45,13 +58,15 @@ def test_create_project():
     assert "Test Project from MCP" in result
     assert "ID:" in result
 
+
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_search_things():
     """Test search functionality."""
-    result = todo_search("Test")
+    result = todo_search("Test", tag="test")
     assert isinstance(result, str)
     assert "Found" in result
     assert "items matching" in result
+
 
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_get_today_tasks():
@@ -61,6 +76,7 @@ def test_get_today_tasks():
     assert "Today's Tasks" in result
     assert "items)" in result
 
+
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_get_inbox_items():
     """Test getting inbox items."""
@@ -69,14 +85,15 @@ def test_get_inbox_items():
     assert "Inbox" in result
     assert "items)" in result
 
+
 def test_tools_handle_errors_gracefully():
     """Test that tools handle errors gracefully when Things 3 is not available."""
     if things3_available():
         pytest.skip("Things 3 is available, cannot test error handling")
-    
+
     # These should return error messages, not raise exceptions
     result = todo_create("Test")
     assert "❌" in result or "✅" in result  # Either error or success
-    
+
     result = todo_list_inbox()
     assert isinstance(result, str)  # Should return a string either way

--- a/thingsbridge/tools.py
+++ b/thingsbridge/tools.py
@@ -7,17 +7,18 @@ from .things3 import client, ThingsError
 
 logger = logging.getLogger(__name__)
 
+
 def todo_create(
     title: str,
     notes: str = "",
     when: Optional[str] = None,
     deadline: Optional[str] = None,
     tags: Optional[List[str]] = None,
-    list_name: Optional[str] = None
+    list_name: Optional[str] = None,
 ) -> str:
     """
     Create a new todo in Things 3.
-    
+
     Args:
         title: The todo title (required)
         notes: Additional notes for the todo
@@ -25,26 +26,26 @@ def todo_create(
         deadline: Deadline for the todo (date YYYY-MM-DD)
         tags: List of tag names to apply
         list_name: Name of project or area to add todo to
-    
+
     Returns:
         Success message with todo ID
-    
+
     See also: todo_create_bulk
     """
     try:
         # Ensure Things 3 is running
         client.ensure_running()
-        
+
         # Escape quotes in strings
         safe_title = title.replace('"', '\\"')
         safe_notes = notes.replace('"', '\\"') if notes else ""
-        
+
         # Build the AppleScript
         properties = [f'name:"{safe_title}"']
-        
+
         if safe_notes:
             properties.append(f'notes:"{safe_notes}"')
-        
+
         # Handle scheduling
         if when:
             when_lower = when.lower()
@@ -53,75 +54,80 @@ def todo_create(
             elif when_lower == "tomorrow":
                 properties.append("due date:((current date) + 1 * days)")
             elif when_lower == "someday":
-                properties.append("area name:\"Someday\"")
+                properties.append('area name:"Someday"')
             else:
                 # Try to parse as date
                 try:
                     parsed_date = datetime.strptime(when, "%Y-%m-%d")
-                    properties.append(f'due date:(date "{parsed_date.strftime("%B %d, %Y %H:%M:%S")}")')
+                    properties.append(
+                        f'due date:(date "{parsed_date.strftime("%B %d, %Y %H:%M:%S")}")'
+                    )
                 except ValueError:
                     logger.warning(f"Invalid date format for when: {when}")
-        
+
         # Handle deadline
         if deadline:
             try:
                 parsed_deadline = datetime.strptime(deadline, "%Y-%m-%d")
-                properties.append(f'deadline:(date "{parsed_deadline.strftime("%B %d, %Y %H:%M:%S")}")')
+                properties.append(
+                    f'deadline:(date "{parsed_deadline.strftime("%B %d, %Y %H:%M:%S")}")'
+                )
             except ValueError:
                 logger.warning(f"Invalid date format for deadline: {deadline}")
-        
+
         # Note: We'll handle tags after creation due to AppleScript limitations
-        
+
         properties_str = ", ".join(properties)
-        
+
         # Build script with optional list assignment
         if list_name:
             safe_list_name = list_name.replace('"', '\\"')
-            script = f'''
+            script = f"""
             tell application "Things3"
                 set targetList to list "{safe_list_name}"
                 set newToDo to make new to do at targetList with properties {{{properties_str}}}
                 return id of newToDo
             end tell
-            '''
+            """
         else:
-            script = f'''
+            script = f"""
             tell application "Things3"
                 set newToDo to make new to do with properties {{{properties_str}}}
                 return id of newToDo
             end tell
-            '''
-        
+            """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to create todo: {result.error}")
-        
+
         todo_id = result.output
-        
+
         # Add tags after creation if specified
         if tags:
             try:
                 for tag in tags:
                     safe_tag = tag.replace('"', '\\"')
-                    tag_script = f'''
+                    tag_script = f"""
                     tell application "Things3"
                         set targetToDo to to do id "{todo_id}"
                         make new tag at targetToDo with properties {{name:"{safe_tag}"}}
                     end tell
-                    '''
+                    """
                     tag_result = client.executor.execute(tag_script)
                     if not tag_result.success:
                         logger.warning(f"Failed to add tag '{tag}': {tag_result.error}")
             except Exception as e:
                 logger.warning(f"Error adding tags: {e}")
-        
+
         tag_info = f" with tags: {', '.join(tags)}" if tags else ""
         return f"✅ Created todo '{title}'{tag_info} with ID: {todo_id}"
-        
+
     except Exception as e:
         logger.error(f"Error creating todo: {e}")
         return f"❌ Failed to create todo: {str(e)}"
+
 
 def project_create(
     title: str,
@@ -129,11 +135,11 @@ def project_create(
     when: Optional[str] = None,
     deadline: Optional[str] = None,
     tags: Optional[List[str]] = None,
-    area: Optional[str] = None
+    area: Optional[str] = None,
 ) -> str:
     """
     Create a new project in Things 3.
-    
+
     Args:
         title: The project title (required)
         notes: Additional notes for the project
@@ -141,21 +147,21 @@ def project_create(
         deadline: Deadline for the project
         tags: List of tag names to apply
         area: Area to add project to
-    
+
     Returns:
         Success message with project ID
     """
     try:
         client.ensure_running()
-        
+
         safe_title = title.replace('"', '\\"')
         safe_notes = notes.replace('"', '\\"') if notes else ""
-        
+
         properties = [f'name:"{safe_title}"']
-        
+
         if safe_notes:
             properties.append(f'notes:"{safe_notes}"')
-        
+
         # Handle scheduling (similar to todos)
         if when:
             when_lower = when.lower()
@@ -163,65 +169,100 @@ def project_create(
                 properties.append("due date:(current date)")
             elif when_lower == "tomorrow":
                 properties.append("due date:((current date) + 1 * days)")
-        
+
         if deadline:
             try:
                 parsed_deadline = datetime.strptime(deadline, "%Y-%m-%d")
-                properties.append(f'deadline:(date "{parsed_deadline.strftime("%B %d, %Y %H:%M:%S")}")')
+                properties.append(
+                    f'deadline:(date "{parsed_deadline.strftime("%B %d, %Y %H:%M:%S")}")'
+                )
             except ValueError:
                 logger.warning(f"Invalid date format for deadline: {deadline}")
-        
+
         if tags:
             escaped_tags = [tag.replace('"', '\\"') for tag in tags]
             tag_list = "{" + ", ".join([f'"{tag}"' for tag in escaped_tags]) + "}"
             properties.append(f"tag names:{tag_list}")
-        
+
         if area:
             safe_area = area.replace('"', '\\"')
             properties.append(f'area:area "{safe_area}"')
-        
+
         properties_str = ", ".join(properties)
-        
-        script = f'''
+
+        script = f"""
         tell application "Things3"
             set newProject to make new project with properties {{{properties_str}}}
             return id of newProject
         end tell
-        '''
-        
+        """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to create project: {result.error}")
-        
+
         project_id = result.output
         return f"📁 Created project '{title}' with ID: {project_id}"
-        
+
     except Exception as e:
         logger.error(f"Error creating project: {e}")
         return f"❌ Failed to create project: {str(e)}"
 
-def todo_search(query: str, limit: int = 10) -> str:
+
+def todo_search(
+    query: str,
+    limit: int = 10,
+    project: Optional[str] = None,
+    area: Optional[str] = None,
+    tag: Optional[str] = None,
+    status: Optional[str] = None,
+) -> str:
     """
     Search for todos and projects in Things 3.
-    
+
     Args:
         query: Search query
         limit: Maximum number of results to return
-    
+        project: Only show items from this project
+        area: Only show items from this area
+        tag: Only show items with this tag
+        status: Only show items with this status (open, completed, canceled)
+
     Returns:
         Formatted search results
     """
     try:
         client.ensure_running()
-        
+
         safe_query = query.replace('"', '\\"')
-        
-        script = f'''
+
+        conditions = []
+        if query:
+            conditions.append(f'name contains "{safe_query}"')
+        if project:
+            safe_project = project.replace('"', '\\"')
+            conditions.append(f'project is project "{safe_project}"')
+        if area:
+            safe_area = area.replace('"', '\\"')
+            conditions.append(f'area is area "{safe_area}"')
+        if tag:
+            safe_tag = tag.replace('"', '\\"')
+            conditions.append(f'tag names contains "{safe_tag}"')
+        if status:
+            conditions.append(f"status is {status.lower()}")
+
+        if conditions:
+            condition_str = " and ".join(conditions)
+            search_clause = f"to dos whose {condition_str}"
+        else:
+            search_clause = "to dos"
+
+        script = f"""
         tell application "Things3"
-            set searchResults to to dos whose name contains "{safe_query}"
+            set searchResults to {search_clause}
             set resultCount to count of searchResults
-            set resultText to "Found " & resultCount & " items matching '" & "{safe_query}" & "':\\n"
+            set resultText to "Found " & resultCount & " items matching '{safe_query}':\\n"
             
             repeat with i from 1 to (resultCount)
                 if i > {limit} then exit repeat
@@ -243,30 +284,31 @@ def todo_search(query: str, limit: int = 10) -> str:
             
             return resultText
         end tell
-        '''
-        
+        """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Search failed: {result.error}")
-        
+
         return result.output
-        
+
     except Exception as e:
         logger.error(f"Error searching: {e}")
         return f"❌ Search failed: {str(e)}"
 
+
 def todo_list_today() -> str:
     """
     Get today's scheduled tasks.
-    
+
     Returns:
         Formatted list of today's tasks
     """
     try:
         client.ensure_running()
-        
-        script = '''
+
+        script = """
         tell application "Things3"
             set todayTodos to to dos of list "Today"
             set taskCount to count of todayTodos
@@ -287,18 +329,19 @@ def todo_list_today() -> str:
             
             return resultText
         end tell
-        '''
-        
+        """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to get today's tasks: {result.error}")
-        
+
         return result.output
-        
+
     except Exception as e:
         logger.error(f"Error getting today's tasks: {e}")
         return f"❌ Failed to get today's tasks: {str(e)}"
+
 
 ##############################
 # BULK OPERATION TOOLS (ADV-004)
@@ -328,7 +371,9 @@ def _build_result(index: int, todo_id: str = None, error: str = None):
     return {"index": index, "id": todo_id}
 
 
-def todo_create_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+def todo_create_bulk(
+    idempotency_key: str, items: List[Dict[str, Any]]
+) -> Dict[str, Any]:
     """Create multiple todos in one batch.
 
     Args:
@@ -436,7 +481,9 @@ def todo_move_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[st
     }
 
 
-def todo_update_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[str, Any]:
+def todo_update_bulk(
+    idempotency_key: str, items: List[Dict[str, Any]]
+) -> Dict[str, Any]:
     """Update multiple todos.
 
     Each item: {"todo_id": str, "title?": str, "notes?": str, "when?": str, "deadline?": str}
@@ -455,7 +502,9 @@ def todo_update_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[
             notes = itm.get("notes")
             when = itm.get("when")
             deadline = itm.get("deadline")
-            res = update_todo(todo_id, title or None, notes or None, when or None, deadline or None)
+            res = update_todo(
+                todo_id, title or None, notes or None, when or None, deadline or None
+            )
             ok = not res.startswith("❌")
             if ok:
                 results.append(_build_result(idx, todo_id=todo_id))
@@ -474,19 +523,21 @@ def todo_update_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[
         "failed": failed,
     }
 
+
 # ---- existing function below ----
+
 
 def todo_list_inbox() -> str:
     """
     Get items in the inbox.
-    
+
     Returns:
         Formatted list of inbox items
     """
     try:
         client.ensure_running()
-        
-        script = '''
+
+        script = """
         tell application "Things3"
             set inboxTodos to to dos of list "Inbox"
             set taskCount to count of inboxTodos
@@ -507,25 +558,26 @@ def todo_list_inbox() -> str:
             
             return resultText
         end tell
-        '''
-        
+        """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to get inbox items: {result.error}")
-        
+
         return result.output
-        
+
     except Exception as e:
         logger.error(f"Error getting inbox items: {e}")
         return f"❌ Failed to get inbox items: {str(e)}"
+
 
 def todo_update(
     todo_id: str,
     title: Optional[str] = None,
     notes: Optional[str] = None,
     when: Optional[str] = None,
-    deadline: Optional[str] = None
+    deadline: Optional[str] = None,
 ) -> str:
     """
     Update an existing todo in Things 3.
@@ -544,70 +596,73 @@ def todo_update(
     """
     try:
         client.ensure_running()
-        
+
         safe_id = todo_id.replace('"', '\\"')
         updates = []
-        
+
         if title:
             safe_title = title.replace('"', '\\"')
             updates.append(f'set name of targetToDo to "{safe_title}"')
-        
+
         if notes is not None:  # Allow empty string to clear notes
-            safe_notes = notes.replace('"', '\\"').replace('!', '\\!')
+            safe_notes = notes.replace('"', '\\"').replace("!", "\\!")
             updates.append(f'set notes of targetToDo to "{safe_notes}"')
-        
+
         if when:
             when_lower = when.lower()
             if when_lower == "today":
                 updates.append("set due date of targetToDo to (current date)")
             elif when_lower == "tomorrow":
-                updates.append("set due date of targetToDo to ((current date) + 1 * days)")
+                updates.append(
+                    "set due date of targetToDo to ((current date) + 1 * days)"
+                )
             elif when_lower == "someday":
                 updates.append("set due date of targetToDo to missing value")
             else:
                 try:
                     parsed_date = datetime.strptime(when, "%Y-%m-%d")
-                    updates.append(f'set due date of targetToDo to (date "{parsed_date.strftime("%B %d, %Y %H:%M:%S")}")')
+                    updates.append(
+                        f'set due date of targetToDo to (date "{parsed_date.strftime("%B %d, %Y %H:%M:%S")}")'
+                    )
                 except ValueError:
                     logger.warning(f"Invalid date format for when: {when}")
-        
+
         if deadline:
             try:
                 parsed_deadline = datetime.strptime(deadline, "%Y-%m-%d")
-                updates.append(f'set deadline of targetToDo to (date "{parsed_deadline.strftime("%B %d, %Y %H:%M:%S")}")')
+                updates.append(
+                    f'set deadline of targetToDo to (date "{parsed_deadline.strftime("%B %d, %Y %H:%M:%S")}")'
+                )
             except ValueError:
                 logger.warning(f"Invalid date format for deadline: {deadline}")
-        
+
         if not updates:
             return "❌ No updates specified"
-        
+
         updates_str = "\n            ".join(updates)
-        
-        script = f'''
+
+        script = f"""
         tell application "Things3"
             set targetToDo to to do id "{safe_id}"
             {updates_str}
             return name of targetToDo
         end tell
-        '''
-        
+        """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to update todo: {result.error}")
-        
+
         todo_name = result.output
         return f"✏️ Updated todo: {todo_name}"
-        
+
     except Exception as e:
         logger.error(f"Error updating todo: {e}")
         return f"❌ Failed to update todo: {str(e)}"
 
-def todo_move(
-    todo_id: str,
-    destination_type: str,
-    destination_name: str
-) -> str:
+
+def todo_move(todo_id: str, destination_type: str, destination_name: str) -> str:
     """
     Move a todo to a different area, project, or list in Things 3.
 
@@ -623,55 +678,57 @@ def todo_move(
     """
     try:
         client.ensure_running()
-        
+
         safe_id = todo_id.replace('"', '\\"')
         safe_destination = destination_name.replace('"', '\\"')
-        
+
         # Build AppleScript based on destination type
         if destination_type.lower() == "area":
-            script = f'''
+            script = f"""
             tell application "Things3"
                 set targetToDo to to do id "{safe_id}"
                 set targetArea to area "{safe_destination}"
                 move targetToDo to targetArea
                 return name of targetToDo
             end tell
-            '''
+            """
         elif destination_type.lower() == "project":
-            script = f'''
+            script = f"""
             tell application "Things3"
                 set targetToDo to to do id "{safe_id}"
                 set targetProject to project "{safe_destination}"
                 move targetToDo to targetProject
                 return name of targetToDo
             end tell
-            '''
+            """
         elif destination_type.lower() == "list":
-            script = f'''
+            script = f"""
             tell application "Things3"
                 set targetToDo to to do id "{safe_id}"
                 set targetList to list "{safe_destination}"
                 move targetToDo to targetList
                 return name of targetToDo
             end tell
-            '''
+            """
         else:
             return f"❌ Invalid destination type: {destination_type}. Use 'area', 'project', or 'list'"
-        
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to move todo: {result.error}")
-        
+
         todo_name = result.output
         return f"📁 Moved todo '{todo_name}' to {destination_type} '{destination_name}'"
-        
+
     except Exception as e:
         logger.error(f"Error moving todo: {e}")
         return f"❌ Failed to move todo: {str(e)}"
 
+
 # Note: get_areas and get_projects functions have been moved to resources.py
 # and are now implemented as MCP resources rather than tools.
+
 
 def todo_complete(todo_id: str) -> str:
     """
@@ -687,25 +744,25 @@ def todo_complete(todo_id: str) -> str:
     """
     try:
         client.ensure_running()
-        
+
         safe_id = todo_id.replace('"', '\\"')
-        
-        script = f'''
+
+        script = f"""
         tell application "Things3"
             set targetToDo to to do id "{safe_id}"
             set status of targetToDo to completed
             return name of targetToDo
         end tell
-        '''
-        
+        """
+
         result = client.executor.execute(script)
-        
+
         if not result.success:
             raise ThingsError(f"Failed to complete todo: {result.error}")
-        
+
         todo_name = result.output
         return f"✅ Completed todo: {todo_name}"
-        
+
     except Exception as e:
         logger.error(f"Error completing todo: {e}")
         return f"❌ Failed to complete todo: {str(e)}"


### PR DESCRIPTION
## Summary
- extend `todo_search` to allow filtering by project, area, tag or status
- update AppleScript query building to handle optional filters
- adjust tests for new signature

## Testing
- `ruff check .` *(fails: unrecognized subcommand or style issues)*
- `black thingsbridge/tools.py tests/test_tools.py`
- `pytest -q` *(fails: osascript not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef79f0f748332b569f51a66bc99fa