### PR TITLE
Rename listing tools to natural names

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,18 @@ curl -X POST http://localhost:8000/tools/todo_create_bulk \
       }' | jq
 ```
 
+
 The response schema follows `docs/batch-tools-guidelines.txt` and includes per-item status information.
+
+Available tools:
+* `todo_create`
+* `project_create`
+* `todo_update`
+* `todo_search`
+* `list_today_tasks`
+* `list_inbox_items`
+* `todo_complete`
+* `todo_move`
 
 Available batch tools:
 * `todo_create_bulk`

--- a/test_server.py
+++ b/test_server.py
@@ -15,8 +15,14 @@ async def test_server_startup():
     
     # Test that tools are registered
     expected_tools = [
-        "_hello_things", "create_todo", "create_project", "update_todo",
-        "search_things", "get_today_tasks", "get_inbox_items", "complete_todo"
+        "_hello_things",
+        "create_todo",
+        "create_project",
+        "update_todo",
+        "search_things",
+        "list_today_tasks",
+        "list_inbox_items",
+        "complete_todo",
     ]
     
     # Get registered tool names from tool manager

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,8 +5,8 @@ from thingsbridge.tools import (
     todo_create,
     project_create,
     todo_search,
-    todo_list_today,
-    todo_list_inbox,
+    list_today_tasks,
+    list_inbox_items,
     todo_complete,
 )
 
@@ -71,7 +71,7 @@ def test_search_things():
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_get_today_tasks():
     """Test getting today's tasks."""
-    result = todo_list_today()
+    result = list_today_tasks()
     assert isinstance(result, str)
     assert "Today's Tasks" in result
     assert "items)" in result
@@ -80,7 +80,7 @@ def test_get_today_tasks():
 @pytest.mark.skipif(not things3_available(), reason="Things 3 not available")
 def test_get_inbox_items():
     """Test getting inbox items."""
-    result = todo_list_inbox()
+    result = list_inbox_items()
     assert isinstance(result, str)
     assert "Inbox" in result
     assert "items)" in result
@@ -95,5 +95,5 @@ def test_tools_handle_errors_gracefully():
     result = todo_create("Test")
     assert "❌" in result or "✅" in result  # Either error or success
 
-    result = todo_list_inbox()
+    result = list_inbox_items()
     assert isinstance(result, str)  # Should return a string either way

--- a/thingsbridge/server.py
+++ b/thingsbridge/server.py
@@ -3,10 +3,18 @@
 from fastmcp import FastMCP
 from typing import Optional, List
 from .tools import (
-    todo_create, project_create, todo_update, todo_search, 
-    todo_list_today, todo_list_inbox, todo_complete,
+    todo_create,
+    project_create,
+    todo_update,
+    todo_search,
+    list_today_tasks,
+    list_inbox_items,
+    todo_complete,
     todo_move,
-    todo_create_bulk, todo_update_bulk, todo_move_bulk, todo_complete_bulk
+    todo_create_bulk,
+    todo_update_bulk,
+    todo_move_bulk,
+    todo_complete_bulk,
 )
 from .resources import areas_list, projects_list, today_tasks, inbox_items
 
@@ -25,8 +33,8 @@ todo_create_tool = mcp.tool(todo_create)
 project_create_tool = mcp.tool(project_create)
 todo_update_tool = mcp.tool(todo_update)
 todo_search_tool = mcp.tool(todo_search)
-todo_list_today_tool = mcp.tool(todo_list_today)
-todo_list_inbox_tool = mcp.tool(todo_list_inbox)
+list_today_tasks_tool = mcp.tool(list_today_tasks)
+list_inbox_items_tool = mcp.tool(list_inbox_items)
 todo_complete_tool = mcp.tool(todo_complete)
 todo_move_tool = mcp.tool(todo_move)
 # Register bulk operation tools

--- a/thingsbridge/tools.py
+++ b/thingsbridge/tools.py
@@ -298,7 +298,7 @@ def todo_search(
         return f"❌ Search failed: {str(e)}"
 
 
-def todo_list_today() -> str:
+def list_today_tasks() -> str:
     """
     Get today's scheduled tasks.
 
@@ -527,7 +527,7 @@ def todo_update_bulk(
 # ---- existing function below ----
 
 
-def todo_list_inbox() -> str:
+def list_inbox_items() -> str:
     """
     Get items in the inbox.
 


### PR DESCRIPTION
## Summary
- rename `todo_list_today` -> `list_today_tasks`
- rename `todo_list_inbox` -> `list_inbox_items`
- update server registrations and tests
- document new tool names in README

## Testing
- `pytest -q` *(fails: AppleScript and async dependencies missing)*
- `fastmcp inspect thingsbridge/server.py:mcp -o schema.json` *(fails: attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_685f0e7c1ba8833291a34434e79ebcf7