### PR TITLE
Auto-generate idempotency keys for bulk tools

### DIFF
--- a/tests/test_bulk_tools.py
+++ b/tests/test_bulk_tools.py
@@ -7,6 +7,10 @@ from thingsbridge.tools import (
     create_todo_bulk,
     move_todo_bulk,
     update_todo_bulk,
+    complete_todo_bulk_auto,
+    create_todo_bulk_auto,
+    move_todo_bulk_auto,
+    update_todo_bulk_auto,
 )
 
 # Helper
@@ -27,6 +31,13 @@ def things3_available():
 def test_create_bulk_validation_error():
     resp = create_todo_bulk(idempotency_key="", items=[])
     assert "error" in resp
+
+
+def test_auto_idempotency_generation():
+    """Wrapper should auto supply idempotency key."""
+    resp = create_todo_bulk_auto(items=[])
+    assert resp.get("error") == "`items` list cannot be empty"
+    assert "idempotency_key" not in resp.get("error", "")
 
 
 def test_update_bulk_max_exceeded():

--- a/thingsbridge/server.py
+++ b/thingsbridge/server.py
@@ -30,40 +30,148 @@ def _hello_things() -> str:
 
 
 # Register test tool
-hello_things = mcp.tool(_hello_things)
+hello_things = mcp.tool(
+    _hello_things,
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
+    tags={"action"},
+)
 
 # Register core MCP tools
-create_todo_tool = mcp.tool(create_todo)
-create_project_tool = mcp.tool(create_project)
-update_todo_tool = mcp.tool(update_todo)
-search_todo_tool = mcp.tool(search_todo)
-list_today_tasks_tool = mcp.tool(list_today_tasks)
-list_inbox_items_tool = mcp.tool(list_inbox_items)
+create_todo_tool = mcp.tool(
+    create_todo,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+    },
+    tags={"action"},
+)
+create_project_tool = mcp.tool(
+    create_project,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": False,
+    },
+    tags={"action"},
+)
+update_todo_tool = mcp.tool(
+    update_todo,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"action", "destructive"},
+)
+search_todo_tool = mcp.tool(
+    search_todo,
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
+    tags={"search"},
+)
+list_today_tasks_tool = mcp.tool(
+    list_today_tasks,
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
+    tags={"listing"},
+)
+list_inbox_items_tool = mcp.tool(
+    list_inbox_items,
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
+    tags={"listing"},
+)
 # list_* wrappers
 list_areas_tool = mcp.tool(
     list_areas,
-    annotations={"readOnlyHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
     tags={"listing"},
 )
 list_projects_tool = mcp.tool(
     list_projects,
-    annotations={"readOnlyHint": True},
+    annotations={
+        "readOnlyHint": True,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
     tags={"listing"},
 )
-complete_todo_tool = mcp.tool(complete_todo)
-move_todo_tool = mcp.tool(move_todo)
+complete_todo_tool = mcp.tool(
+    complete_todo,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"action", "destructive"},
+)
+move_todo_tool = mcp.tool(
+    move_todo,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"action", "destructive"},
+)
 # Register bulk operation tools with auto-generated keys
 create_bulk_tool = mcp.tool(
-    create_todo_bulk_auto, exclude_args=["idempotency_key"]
+    create_todo_bulk_auto,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": False,
+        "idempotentHint": True,
+    },
+    tags={"batch", "action"},
+    exclude_args=["idempotency_key"],
 )
 update_bulk_tool = mcp.tool(
-    update_todo_bulk_auto, exclude_args=["idempotency_key"]
+    update_todo_bulk_auto,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"batch", "action", "destructive"},
+    exclude_args=["idempotency_key"],
 )
 move_bulk_tool = mcp.tool(
-    move_todo_bulk_auto, exclude_args=["idempotency_key"]
+    move_todo_bulk_auto,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"batch", "action", "destructive"},
+    exclude_args=["idempotency_key"],
 )
 complete_bulk_tool = mcp.tool(
-    complete_todo_bulk_auto, exclude_args=["idempotency_key"]
+    complete_todo_bulk_auto,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"batch", "action", "destructive"},
+    exclude_args=["idempotency_key"],
 )
 
 

--- a/thingsbridge/server.py
+++ b/thingsbridge/server.py
@@ -5,19 +5,19 @@ from fastmcp import FastMCP
 from .resources import areas_list, inbox_items, projects_list, today_tasks
 from .tools import (
     complete_todo,
-    complete_todo_bulk,
+    complete_todo_bulk_auto,
     create_project,
     create_todo,
-    create_todo_bulk,
+    create_todo_bulk_auto,
     list_areas,
     list_inbox_items,
     list_projects,
     list_today_tasks,
     move_todo,
-    move_todo_bulk,
+    move_todo_bulk_auto,
     search_todo,
     update_todo,
-    update_todo_bulk,
+    update_todo_bulk_auto,
 )
 
 # Initialize the MCP server
@@ -52,11 +52,19 @@ list_projects_tool = mcp.tool(
 )
 complete_todo_tool = mcp.tool(complete_todo)
 move_todo_tool = mcp.tool(move_todo)
-# Register bulk operation tools
-create_bulk_tool = mcp.tool(create_todo_bulk)
-update_bulk_tool = mcp.tool(update_todo_bulk)
-move_bulk_tool = mcp.tool(move_todo_bulk)
-complete_bulk_tool = mcp.tool(complete_todo_bulk)
+# Register bulk operation tools with auto-generated keys
+create_bulk_tool = mcp.tool(
+    create_todo_bulk_auto, exclude_args=["idempotency_key"]
+)
+update_bulk_tool = mcp.tool(
+    update_todo_bulk_auto, exclude_args=["idempotency_key"]
+)
+move_bulk_tool = mcp.tool(
+    move_todo_bulk_auto, exclude_args=["idempotency_key"]
+)
+complete_bulk_tool = mcp.tool(
+    complete_todo_bulk_auto, exclude_args=["idempotency_key"]
+)
 
 
 # Register MCP resources using correct FastMCP syntax

--- a/thingsbridge/tools.py
+++ b/thingsbridge/tools.py
@@ -378,11 +378,15 @@ def create_todo_bulk(
 ) -> Dict[str, Any]:
     """Create multiple todos in one batch.
 
+    Use this when you need to create many todos at once.
+
     Args:
         idempotency_key: Client-supplied key for safe retries.
         items: List of {"title": str, "notes": str?} objects.
     Returns:
         Bulk response dict following guidelines.
+
+    See also: create_todo
     """
     validation_error = _validate_batch(items, idempotency_key)
     if validation_error:
@@ -414,7 +418,10 @@ def create_todo_bulk(
 
 
 def complete_todo_bulk(idempotency_key: str, items: List[str]) -> Dict[str, Any]:
-    """Complete many todos given their IDs."""
+    """Complete multiple todos in one batch.
+
+    See also: complete_todo
+    """
     if not isinstance(items, list):
         return {"error": "items must be list of todo IDs"}
     validation_error = _validate_batch(items, idempotency_key)
@@ -450,6 +457,8 @@ def move_todo_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[st
     """Move multiple todos in one call.
 
     Each item: {"todo_id": str, "destination_type": "area|project|list", "destination_name": str}
+
+    See also: move_todo
     """
     validation_error = _validate_batch(items, idempotency_key)
     if validation_error:
@@ -486,9 +495,11 @@ def move_todo_bulk(idempotency_key: str, items: List[Dict[str, Any]]) -> Dict[st
 def update_todo_bulk(
     idempotency_key: str, items: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
-    """Update multiple todos.
+    """Update multiple todos in one batch.
 
     Each item: {"todo_id": str, "title?": str, "notes?": str, "when?": str, "deadline?": str}
+
+    See also: update_todo
     """
     validation_error = _validate_batch(items, idempotency_key)
     if validation_error:

--- a/thingsbridge/tools.py
+++ b/thingsbridge/tools.py
@@ -526,6 +526,39 @@ def update_todo_bulk(
     }
 
 
+# Convenience wrappers to auto-generate idempotency keys --------------------
+def create_todo_bulk_auto(
+    *, items: List[Dict[str, Any]], idempotency_key: Optional[str] = None
+) -> Dict[str, Any]:
+    """Wrapper for :func:`create_todo_bulk` with auto idempotency key."""
+
+    return create_todo_bulk(idempotency_key or uuid.uuid4().hex, items)
+
+
+def complete_todo_bulk_auto(
+    *, items: List[str], idempotency_key: Optional[str] = None
+) -> Dict[str, Any]:
+    """Wrapper for :func:`complete_todo_bulk` with auto idempotency key."""
+
+    return complete_todo_bulk(idempotency_key or uuid.uuid4().hex, items)
+
+
+def move_todo_bulk_auto(
+    *, items: List[Dict[str, Any]], idempotency_key: Optional[str] = None
+) -> Dict[str, Any]:
+    """Wrapper for :func:`move_todo_bulk` with auto idempotency key."""
+
+    return move_todo_bulk(idempotency_key or uuid.uuid4().hex, items)
+
+
+def update_todo_bulk_auto(
+    *, items: List[Dict[str, Any]], idempotency_key: Optional[str] = None
+) -> Dict[str, Any]:
+    """Wrapper for :func:`update_todo_bulk` with auto idempotency key."""
+
+    return update_todo_bulk(idempotency_key or uuid.uuid4().hex, items)
+
+
 # ---- existing function below ----
 
 


### PR DESCRIPTION
## Summary
- wrap bulk helper functions with auto idempotency key generation
- register wrapped bulk tools on the server and hide `idempotency_key`
- test auto-generation in bulk tools

## Testing
- `pytest -q`
- `pytest tests/test_bulk_tools.py::test_auto_idempotency_generation -q`


------
https://chatgpt.com/codex/tasks/task_e_685f22199754833280c7aca1a1fbada3