### PR TITLE
Fix bulk todo tags

### DIFF
--- a/thingsbridge/applescript_builder.py
+++ b/thingsbridge/applescript_builder.py
@@ -11,21 +11,20 @@ def _sanitize_applescript_string(text: str) -> str:
 
 
 def build_todo_creation_script(
-    properties: List[str], 
-    target_list: Optional[str] = None
+    properties: List[str], target_list: Optional[str] = None
 ) -> str:
     """
     Build AppleScript for creating a todo with given properties.
-    
+
     Args:
         properties: List of property strings (e.g., 'name:"Todo Title"')
         target_list: Optional target list name
-        
+
     Returns:
         Complete AppleScript string
     """
     properties_str = ", ".join(properties)
-    
+
     if target_list:
         safe_list_name = _sanitize_applescript_string(target_list)
         return f"""
@@ -47,15 +46,15 @@ def build_todo_creation_script(
 def build_project_creation_script(properties: List[str]) -> str:
     """
     Build AppleScript for creating a project with given properties.
-    
+
     Args:
         properties: List of property strings
-        
+
     Returns:
         Complete AppleScript string
     """
     properties_str = ", ".join(properties)
-    
+
     return f"""
     tell application "Things3"
         set newProject to make new project with properties {{{properties_str}}}
@@ -67,17 +66,17 @@ def build_project_creation_script(properties: List[str]) -> str:
 def build_todo_update_script(todo_id: str, updates: List[str]) -> str:
     """
     Build AppleScript for updating a todo with given changes.
-    
+
     Args:
         todo_id: The ID of the todo to update
         updates: List of update statements (e.g., 'set name of targetToDo to "New Name"')
-        
+
     Returns:
         Complete AppleScript string
     """
     safe_id = _sanitize_applescript_string(todo_id)
     updates_str = "\n            ".join(updates)
-    
+
     return f"""
     tell application "Things3"
         set targetToDo to to do id "{safe_id}"
@@ -88,18 +87,16 @@ def build_todo_update_script(todo_id: str, updates: List[str]) -> str:
 
 
 def build_search_script(
-    search_clause: str, 
-    limit: int = 10, 
-    safe_query: str = ""
+    search_clause: str, limit: int = 10, safe_query: str = ""
 ) -> str:
     """
     Build AppleScript for searching todos with optional conditions.
-    
+
     Args:
         search_clause: The search clause (e.g., "to dos whose name contains 'test'")
         limit: Maximum number of results
         safe_query: Safe query string for result message
-        
+
     Returns:
         Complete AppleScript string
     """
@@ -149,11 +146,11 @@ def build_search_script(
 def build_list_script(list_name: str, list_title: str) -> str:
     """
     Build AppleScript for listing items from a specific list.
-    
+
     Args:
         list_name: Name of the Things 3 list
         list_title: Display title for the results
-        
+
     Returns:
         Complete AppleScript string
     """
@@ -184,15 +181,15 @@ def build_list_script(list_name: str, list_title: str) -> str:
 def build_completion_script(todo_id: str) -> str:
     """
     Build AppleScript for completing a todo.
-    
+
     Args:
         todo_id: The ID of the todo to complete
-        
+
     Returns:
         Complete AppleScript string
     """
     safe_id = _sanitize_applescript_string(todo_id)
-    
+
     return f"""
     tell application "Things3"
         set targetToDo to to do id "{safe_id}"
@@ -203,24 +200,22 @@ def build_completion_script(todo_id: str) -> str:
 
 
 def build_move_script(
-    todo_id: str, 
-    destination_type: str, 
-    destination_name: str
+    todo_id: str, destination_type: str, destination_name: str
 ) -> str:
     """
     Build AppleScript for moving a todo to a different location.
-    
+
     Args:
         todo_id: The ID of the todo to move
         destination_type: Type of destination ("area", "project", "list")
         destination_name: Name of the destination
-        
+
     Returns:
         Complete AppleScript string or error message
     """
     safe_id = _sanitize_applescript_string(todo_id)
     safe_destination = _sanitize_applescript_string(destination_name)
-    
+
     if destination_type.lower() == "area":
         return f"""
         tell application "Things3"
@@ -255,16 +250,16 @@ def build_move_script(
 def build_tag_addition_script(todo_id: str, tag_name: str) -> str:
     """
     Build AppleScript for adding a tag to a todo.
-    
+
     Args:
         todo_id: The ID of the todo
         tag_name: Name of the tag to add
-        
+
     Returns:
         Complete AppleScript string
     """
     safe_tag = _sanitize_applescript_string(tag_name)
-    
+
     return f"""
     tell application "Things3"
         set targetToDo to to do id "{todo_id}"
@@ -276,15 +271,15 @@ def build_tag_addition_script(todo_id: str, tag_name: str) -> str:
 def build_get_name_script(todo_id: str) -> str:
     """
     Build AppleScript for getting a todo's name.
-    
+
     Args:
         todo_id: The ID of the todo
-        
+
     Returns:
         Complete AppleScript string
     """
     safe_id = _sanitize_applescript_string(todo_id)
-    
+
     return f"""
     tell application "Things3"
         return name of to do id "{safe_id}"
@@ -295,17 +290,17 @@ def build_get_name_script(todo_id: str) -> str:
 def build_move_to_list_script(todo_id: str, list_name: str) -> str:
     """
     Build AppleScript for moving a todo to a specific list.
-    
+
     Args:
         todo_id: The ID of the todo
         list_name: Name of the target list
-        
+
     Returns:
         Complete AppleScript string
     """
     safe_id = _sanitize_applescript_string(todo_id)
     safe_list = _sanitize_applescript_string(list_name)
-    
+
     return f"""
     tell application "Things3"
         move to do id "{safe_id}" to list "{safe_list}"
@@ -317,58 +312,69 @@ def build_move_to_list_script(todo_id: str, list_name: str) -> str:
 # BATCH OPERATIONS - Native AppleScript batch processing
 # =============================================================================
 
+
 def build_batch_todo_creation_script(items: list) -> str:
     """
     Build AppleScript for creating multiple todos in a single execution.
-    
+
     Args:
         items: List of dict items with 'title' and optional 'notes', 'when', 'deadline', 'tags', 'list_name'
-        
+
     Returns:
         Complete AppleScript string that returns a list of created todo IDs
     """
     todo_commands = []
-    
+
     for i, item in enumerate(items):
         title = _sanitize_applescript_string(item.get("title", ""))
         notes = _sanitize_applescript_string(item.get("notes", ""))
-        
+
         properties = [f'name:"{title}"']
         if notes:
             properties.append(f'notes:"{notes}"')
-            
+
         # Handle deadline
         deadline = item.get("deadline")
         if deadline:
             # Note: Date validation should be done before calling this function
             properties.append(f'due date:(date "{deadline}")')
-        
+
+        tags = item.get("tags")
+        if tags:
+            escaped_tags = [_sanitize_applescript_string(t) for t in tags]
+            tag_list = "{" + ", ".join([f'"{t}"' for t in escaped_tags]) + "}"
+            properties.append(f"tag names:{tag_list}")
+
         properties_str = ", ".join(properties)
-        
+
         # Handle list assignment
         list_name = item.get("list_name")
         if list_name == "Someday" or (item.get("when", "").lower() == "someday"):
             target_list = "Someday"
         else:
             target_list = list_name
-            
+
         if target_list:
             safe_list = _sanitize_applescript_string(target_list)
-            todo_commands.append(f"""
+            todo_commands.append(
+                f"""
             set targetList{i} to list "{safe_list}"
             set newToDo{i} to make new to do at targetList{i} with properties {{{properties_str}}}
-            set todoId{i} to id of newToDo{i}""")
+            set todoId{i} to id of newToDo{i}"""
+            )
         else:
-            todo_commands.append(f"""
+            todo_commands.append(
+                f"""
             set newToDo{i} to make new to do with properties {{{properties_str}}}
-            set todoId{i} to id of newToDo{i}""")
-    
+            set todoId{i} to id of newToDo{i}"""
+            )
+
     # Build the result collection
     result_ids = [f"todoId{i}" for i in range(len(items))]
     result_list = "{" + ", ".join(result_ids) + "}"
-    
+
     commands_str = "\\n            ".join(todo_commands)
-    
+
     return f"""
     tell application "Things3"
         {commands_str}
@@ -387,28 +393,30 @@ def build_batch_todo_creation_script(items: list) -> str:
 def build_batch_completion_script(todo_ids: list) -> str:
     """
     Build AppleScript for completing multiple todos in a single execution.
-    
+
     Args:
         todo_ids: List of todo ID strings
-        
+
     Returns:
         Complete AppleScript string that returns completed todo names
     """
     completion_commands = []
-    
+
     for i, todo_id in enumerate(todo_ids):
         safe_id = _sanitize_applescript_string(todo_id)
-        completion_commands.append(f"""
+        completion_commands.append(
+            f"""
         set targetToDo{i} to to do id "{safe_id}"
         set todoName{i} to name of targetToDo{i}
-        set status of targetToDo{i} to completed""")
-    
+        set status of targetToDo{i} to completed"""
+        )
+
     # Build the result collection
     result_names = [f"todoName{i}" for i in range(len(todo_ids))]
     result_list = "{" + ", ".join(result_names) + "}"
-    
+
     commands_str = "\\n            ".join(completion_commands)
-    
+
     return f"""
     tell application "Things3"
         {commands_str}
@@ -427,40 +435,42 @@ def build_batch_completion_script(todo_ids: list) -> str:
 def build_batch_update_script(updates: list) -> str:
     """
     Build AppleScript for updating multiple todos in a single execution.
-    
+
     Args:
         updates: List of dict items with 'todo_id' and update fields
-        
+
     Returns:
         Complete AppleScript string that returns updated todo names
     """
     update_commands = []
-    
+
     for i, update in enumerate(updates):
         todo_id = _sanitize_applescript_string(update["todo_id"])
         update_commands.append(f'set targetToDo{i} to to do id "{todo_id}"')
-        
+
         if "title" in update and update["title"]:
             title = _sanitize_applescript_string(update["title"])
             update_commands.append(f'set name of targetToDo{i} to "{title}"')
-            
+
         if "notes" in update and update["notes"] is not None:
             notes = _sanitize_applescript_string(update["notes"]).replace("!", "\\\\!")
             update_commands.append(f'set notes of targetToDo{i} to "{notes}"')
-            
+
         if "deadline" in update and update["deadline"]:
             # Note: Date validation should be done before calling this function
             deadline = update["deadline"]
-            update_commands.append(f'set due date of targetToDo{i} to (date "{deadline}")')
-        
-        update_commands.append(f'set todoName{i} to name of targetToDo{i}')
-    
+            update_commands.append(
+                f'set due date of targetToDo{i} to (date "{deadline}")'
+            )
+
+        update_commands.append(f"set todoName{i} to name of targetToDo{i}")
+
     # Build the result collection
     result_names = [f"todoName{i}" for i in range(len(updates))]
     result_list = "{" + ", ".join(result_names) + "}"
-    
+
     commands_str = "\\n            ".join(update_commands)
-    
+
     return f"""
     tell application "Things3"
         {commands_str}
@@ -479,40 +489,40 @@ def build_batch_update_script(updates: list) -> str:
 def build_batch_move_script(moves: list) -> str:
     """
     Build AppleScript for moving multiple todos in a single execution.
-    
+
     Args:
         moves: List of dict items with 'todo_id', 'destination_type', 'destination_name'
-        
+
     Returns:
         Complete AppleScript string that returns moved todo names
     """
     move_commands = []
-    
+
     for i, move in enumerate(moves):
         todo_id = _sanitize_applescript_string(move["todo_id"])
         dest_type = move["destination_type"].lower()
         dest_name = _sanitize_applescript_string(move["destination_name"])
-        
+
         move_commands.append(f'set targetToDo{i} to to do id "{todo_id}"')
-        
+
         if dest_type == "area":
             move_commands.append(f'set targetArea{i} to area "{dest_name}"')
-            move_commands.append(f'move targetToDo{i} to targetArea{i}')
+            move_commands.append(f"move targetToDo{i} to targetArea{i}")
         elif dest_type == "project":
             move_commands.append(f'set targetProject{i} to project "{dest_name}"')
-            move_commands.append(f'set project of targetToDo{i} to targetProject{i}')
+            move_commands.append(f"set project of targetToDo{i} to targetProject{i}")
         elif dest_type == "list":
             move_commands.append(f'set targetList{i} to list "{dest_name}"')
-            move_commands.append(f'move targetToDo{i} to targetList{i}')
-        
-        move_commands.append(f'set todoName{i} to name of targetToDo{i}')
-    
+            move_commands.append(f"move targetToDo{i} to targetList{i}")
+
+        move_commands.append(f"set todoName{i} to name of targetToDo{i}")
+
     # Build the result collection
     result_names = [f"todoName{i}" for i in range(len(moves))]
     result_list = "{" + ", ".join(result_names) + "}"
-    
+
     commands_str = "\\n            ".join(move_commands)
-    
+
     return f"""
     tell application "Things3"
         {commands_str}


### PR DESCRIPTION
## Summary
- include `tag names` when building AppleScript for bulk todo creation
- apply tags to each todo after batch creation
- test that tags are applied via `create_todo_bulk`

## Testing
- `black thingsbridge/applescript_builder.py thingsbridge/bulk_tools.py tests/test_bulk_tools.py`
- `ruff check thingsbridge/applescript_builder.py thingsbridge/bulk_tools.py tests/test_bulk_tools.py`
- `pytest -q` *(fails: Failed to launch Things 3)*

------
https://chatgpt.com/codex/tasks/task_e_686033396b988332892357eb200acd70