### PR TITLE
Add bulk cancel and delete tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Available batch tools:
 * `update_todo_bulk`
 * `move_todo_bulk`
 * `complete_todo_bulk`
+* `cancel_todo_bulk`
+* `delete_todo_bulk`
 
 ### Naming conventions
 

--- a/tests/test_bulk_tools.py
+++ b/tests/test_bulk_tools.py
@@ -4,6 +4,8 @@ import uuid
 import pytest
 from thingsbridge.tools import (
     complete_todo_bulk,
+    cancel_todo_bulk,
+    delete_todo_bulk,
     create_todo_bulk,
     move_todo_bulk,
     update_todo_bulk,
@@ -38,6 +40,16 @@ def test_update_bulk_max_exceeded():
     items = [{"todo_id": "dummy", "title": "x"} for _ in range(1001)]
     resp = update_todo_bulk(idempotency_key=IDEMPOTENCY_KEY, items=items)
     assert resp.get("error")
+
+
+def test_cancel_bulk_validation_error():
+    resp = cancel_todo_bulk(idempotency_key="", items="notalist")
+    assert "error" in resp
+
+
+def test_delete_bulk_validation_error():
+    resp = delete_todo_bulk(idempotency_key="", items=[])
+    assert "error" in resp
 
 
 # ---------------- Live tests (require Things 3) ---------------- #

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,6 +26,8 @@ def test_all_expected_tools_registered():
         "list_today_tasks",
         "list_inbox_items",
         "complete_todo",
+        "cancel_todo",
+        "delete_todo",
         "move_todo",
         "list_areas",
         "list_projects",
@@ -38,6 +40,8 @@ def test_all_expected_tools_registered():
         "update_todo_bulk",
         "move_todo_bulk",
         "complete_todo_bulk",
+        "cancel_todo_bulk",
+        "delete_todo_bulk",
         # Test tool
         "_hello_things",
     ]
@@ -71,12 +75,16 @@ def test_new_tool_imports():
         search_due_this_week,
         search_scheduled_this_week,
         search_overdue,
+        cancel_todo_bulk,
+        delete_todo_bulk,
     )
     
     # Test that they are callable
     assert callable(search_due_this_week)
     assert callable(search_scheduled_this_week)
     assert callable(search_overdue)
+    assert callable(cancel_todo_bulk)
+    assert callable(delete_todo_bulk)
 
 def test_prompt_resources_exist():
     """Test that prompt resources are registered."""

--- a/thingsbridge/applescript_builder.py
+++ b/thingsbridge/applescript_builder.py
@@ -199,6 +199,33 @@ def build_completion_script(todo_id: str) -> str:
     """
 
 
+def build_cancellation_script(todo_id: str) -> str:
+    """Build AppleScript for canceling a todo."""
+    safe_id = _sanitize_applescript_string(todo_id)
+
+    return f"""
+    tell application "Things3"
+        set targetToDo to to do id "{safe_id}"
+        set status of targetToDo to canceled
+        return name of targetToDo
+    end tell
+    """
+
+
+def build_delete_script(todo_id: str) -> str:
+    """Build AppleScript for deleting a todo."""
+    safe_id = _sanitize_applescript_string(todo_id)
+
+    return f"""
+    tell application "Things3"
+        set targetToDo to to do id "{safe_id}"
+        set todoName to name of targetToDo
+        delete targetToDo
+        return todoName
+    end tell
+    """
+
+
 def build_move_script(
     todo_id: str, destination_type: str, destination_name: str
 ) -> str:
@@ -421,6 +448,72 @@ def build_batch_completion_script(todo_ids: list) -> str:
     tell application "Things3"
         {commands_str}
         
+        set resultNames to {result_list}
+        set resultText to ""
+        repeat with i from 1 to count of resultNames
+            set resultText to resultText & item i of resultNames
+            if i < count of resultNames then set resultText to resultText & "|"
+        end repeat
+        return resultText
+    end tell
+    """
+
+
+def build_batch_cancellation_script(todo_ids: list) -> str:
+    """Build AppleScript for canceling multiple todos."""
+    cancel_commands = []
+
+    for i, todo_id in enumerate(todo_ids):
+        safe_id = _sanitize_applescript_string(todo_id)
+        cancel_commands.append(
+            f"""
+        set targetToDo{i} to to do id \"{safe_id}\"
+        set todoName{i} to name of targetToDo{i}
+        set status of targetToDo{i} to canceled"""
+        )
+
+    result_names = [f"todoName{i}" for i in range(len(todo_ids))]
+    result_list = "{" + ", ".join(result_names) + "}"
+
+    commands_str = "\n            ".join(cancel_commands)
+
+    return f"""
+    tell application \"Things3\"
+        {commands_str}
+
+        set resultNames to {result_list}
+        set resultText to ""
+        repeat with i from 1 to count of resultNames
+            set resultText to resultText & item i of resultNames
+            if i < count of resultNames then set resultText to resultText & "|"
+        end repeat
+        return resultText
+    end tell
+    """
+
+
+def build_batch_delete_script(todo_ids: list) -> str:
+    """Build AppleScript for deleting multiple todos."""
+    delete_commands = []
+
+    for i, todo_id in enumerate(todo_ids):
+        safe_id = _sanitize_applescript_string(todo_id)
+        delete_commands.append(
+            f"""
+        set targetToDo{i} to to do id \"{safe_id}\"
+        set todoName{i} to name of targetToDo{i}
+        delete targetToDo{i}"""
+        )
+
+    result_names = [f"todoName{i}" for i in range(len(todo_ids))]
+    result_list = "{" + ", ".join(result_names) + "}"
+
+    commands_str = "\n            ".join(delete_commands)
+
+    return f"""
+    tell application \"Things3\"
+        {commands_str}
+
         set resultNames to {result_list}
         set resultText to ""
         repeat with i from 1 to count of resultNames

--- a/thingsbridge/core_tools.py
+++ b/thingsbridge/core_tools.py
@@ -9,6 +9,8 @@ from .applescript_builder import (
     build_todo_update_script,
     build_move_script,
     build_completion_script,
+    build_cancellation_script,
+    build_delete_script,
     build_tag_addition_script,
     build_get_name_script,
     build_move_to_list_script,
@@ -385,3 +387,47 @@ def complete_todo(todo_id: str) -> str:
     except Exception as e:
         logger.error(f"Error completing todo: {e}")
         return f"❌ Failed to complete todo: {str(e)}"
+
+
+def cancel_todo(todo_id: str) -> str:
+    """Mark a todo as canceled."""
+    try:
+        if not todo_id or not isinstance(todo_id, str) or not todo_id.strip():
+            return "❌ todo_id is required and cannot be empty"
+
+        client.ensure_running()
+
+        safe_id = todo_id.replace('"', '\\"')
+        script = build_cancellation_script(safe_id)
+        result = client.executor.execute(script)
+
+        if not result.success:
+            raise ThingsError(f"Failed to cancel todo: {result.error}")
+
+        todo_name = result.output
+        return f"🚫 Canceled todo: {todo_name}"
+    except Exception as e:
+        logger.error(f"Error canceling todo: {e}")
+        return f"❌ Failed to cancel todo: {str(e)}"
+
+
+def delete_todo(todo_id: str) -> str:
+    """Delete a todo from Things."""
+    try:
+        if not todo_id or not isinstance(todo_id, str) or not todo_id.strip():
+            return "❌ todo_id is required and cannot be empty"
+
+        client.ensure_running()
+
+        safe_id = todo_id.replace('"', '\\"')
+        script = build_delete_script(safe_id)
+        result = client.executor.execute(script)
+
+        if not result.success:
+            raise ThingsError(f"Failed to delete todo: {result.error}")
+
+        todo_name = result.output
+        return f"🗑️ Deleted todo: {todo_name}"
+    except Exception as e:
+        logger.error(f"Error deleting todo: {e}")
+        return f"❌ Failed to delete todo: {str(e)}"

--- a/thingsbridge/server.py
+++ b/thingsbridge/server.py
@@ -6,7 +6,11 @@ from fastmcp.prompts import Prompt
 from .resources import areas_list, inbox_items, projects_list, today_tasks
 from .tools import (
     complete_todo,
+    cancel_todo,
+    delete_todo,
     complete_todo_bulk,
+    cancel_todo_bulk,
+    delete_todo_bulk,
     create_project,
     create_todo,
     create_todo_bulk,
@@ -127,6 +131,24 @@ complete_todo_tool = mcp.tool(
     },
     tags={"action", "destructive"},
 )
+cancel_todo_tool = mcp.tool(
+    cancel_todo,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"action", "destructive"},
+)
+delete_todo_tool = mcp.tool(
+    delete_todo,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"action", "destructive"},
+)
 move_todo_tool = mcp.tool(
     move_todo,
     annotations={
@@ -166,6 +188,24 @@ move_bulk_tool = mcp.tool(
 )
 complete_bulk_tool = mcp.tool(
     complete_todo_bulk,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"batch", "action", "destructive"},
+)
+cancel_bulk_tool = mcp.tool(
+    cancel_todo_bulk,
+    annotations={
+        "readOnlyHint": False,
+        "destructiveHint": True,
+        "idempotentHint": True,
+    },
+    tags={"batch", "action", "destructive"},
+)
+delete_bulk_tool = mcp.tool(
+    delete_todo_bulk,
     annotations={
         "readOnlyHint": False,
         "destructiveHint": True,

--- a/thingsbridge/tools.py
+++ b/thingsbridge/tools.py
@@ -3,6 +3,8 @@
 # Import all tools from specialized modules
 from .core_tools import (
     complete_todo,
+    cancel_todo,
+    delete_todo,
     create_project,
     create_todo,
     move_todo,
@@ -20,6 +22,8 @@ from .search_tools import (
 )
 from .bulk_tools import (
     complete_todo_bulk,
+    cancel_todo_bulk,
+    delete_todo_bulk,
     create_todo_bulk,
     move_todo_bulk,
     update_todo_bulk,
@@ -32,6 +36,8 @@ __all__ = [
     "create_project", 
     "update_todo",
     "complete_todo",
+    "cancel_todo",
+    "delete_todo",
     "move_todo",
     # Search and listing
     "search_todo",
@@ -45,6 +51,8 @@ __all__ = [
     # Bulk operations
     "create_todo_bulk",
     "update_todo_bulk",
+    "cancel_todo_bulk",
+    "delete_todo_bulk",
     "complete_todo_bulk",
     "move_todo_bulk",
 ]


### PR DESCRIPTION
## Summary
- add AppleScript builders for cancelling and deleting todos
- support single cancel_todo and delete_todo helpers
- implement `cancel_todo_bulk` and `delete_todo_bulk`
- export and register new tools with the MCP server
- update docs and tests for new endpoints

## Testing
- `pytest -q` *(fails: osascript not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603784829083329761f7e5fafe2b11